### PR TITLE
Swap front back

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -172,7 +172,7 @@ namespace diff_drive_controller{
     bool enable_odom_tf_;
 
     /// whether to define the back as the front of the robot instead
-    bool swap_front_and_back_;
+    bool invert_forward_direction_;
 
     /// Number of wheel joints:
     size_t wheel_joints_size_;

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -171,7 +171,7 @@ namespace diff_drive_controller{
     /// Whether to publish odometry to tf or not:
     bool enable_odom_tf_;
 
-    /// whether to define the back as the front of the robot instead
+    /// whether to invert the forward direction, i.e. define the back as the front of the robot
     bool invert_forward_direction_;
 
     /// Number of wheel joints:

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -171,6 +171,9 @@ namespace diff_drive_controller{
     /// Whether to publish odometry to tf or not:
     bool enable_odom_tf_;
 
+    /// whether to define the back as the front of the robot instead
+    bool swap_front_and_back_;
+
     /// Number of wheel joints:
     size_t wheel_joints_size_;
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -435,6 +435,12 @@ namespace diff_drive_controller{
       left_pos  /= wheel_joints_size_;
       right_pos /= wheel_joints_size_;
 
+      if (true) {
+        const double temp = left_pos;
+        left_pos = -right_pos;
+        right_pos = -temp;
+      }
+
       // Estimate linear and angular velocity using joint information
       odometry_.update(left_pos, right_pos, time);
     }
@@ -506,8 +512,14 @@ namespace diff_drive_controller{
     }
 
     // Compute wheels velocities:
-    const double vel_left  = (curr_cmd.lin - curr_cmd.ang * ws / 2.0)/lwr;
-    const double vel_right = (curr_cmd.lin + curr_cmd.ang * ws / 2.0)/rwr;
+    double vel_left  = (curr_cmd.lin - curr_cmd.ang * ws / 2.0)/lwr;
+    double vel_right = (curr_cmd.lin + curr_cmd.ang * ws / 2.0)/rwr;
+
+    if (true) {
+      const double temp = vel_left;
+      vel_left = -vel_right;
+      vel_right = -temp;
+    }
 
     // Set wheels velocities:
     for (size_t i = 0; i < wheel_joints_size_; ++i)

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -156,6 +156,7 @@ namespace diff_drive_controller{
     , base_frame_id_("base_link")
     , odom_frame_id_("odom")
     , enable_odom_tf_(true)
+    , swap_front_and_back_(false)
     , wheel_joints_size_(0)
     , publish_cmd_(false)
     , publish_wheel_joint_controller_state_(false)
@@ -249,6 +250,9 @@ namespace diff_drive_controller{
 
     controller_nh.param("enable_odom_tf", enable_odom_tf_, enable_odom_tf_);
     ROS_INFO_STREAM_NAMED(name_, "Publishing to tf is " << (enable_odom_tf_?"enabled":"disabled"));
+
+    controller_nh.param("swap_front_and_back", swap_front_and_back_, swap_front_and_back_);
+    ROS_INFO_STREAM_NAMED(name_, "Front and back are " << (swap_front_and_back_?"swapped":"not swapped"));
 
     // Velocity and acceleration limits:
     controller_nh.param("linear/x/has_velocity_limits"    , limiter_lin_.has_velocity_limits    , limiter_lin_.has_velocity_limits    );
@@ -435,7 +439,7 @@ namespace diff_drive_controller{
       left_pos  /= wheel_joints_size_;
       right_pos /= wheel_joints_size_;
 
-      if (true) {
+      if (swap_front_and_back_) {
         const double temp = left_pos;
         left_pos = -right_pos;
         right_pos = -temp;
@@ -515,7 +519,7 @@ namespace diff_drive_controller{
     double vel_left  = (curr_cmd.lin - curr_cmd.ang * ws / 2.0)/lwr;
     double vel_right = (curr_cmd.lin + curr_cmd.ang * ws / 2.0)/rwr;
 
-    if (true) {
+    if (swap_front_and_back_) {
       const double temp = vel_left;
       vel_left = -vel_right;
       vel_right = -temp;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -156,7 +156,7 @@ namespace diff_drive_controller{
     , base_frame_id_("base_link")
     , odom_frame_id_("odom")
     , enable_odom_tf_(true)
-    , swap_front_and_back_(false)
+    , invert_forward_direction_(false)
     , wheel_joints_size_(0)
     , publish_cmd_(false)
     , publish_wheel_joint_controller_state_(false)
@@ -251,8 +251,8 @@ namespace diff_drive_controller{
     controller_nh.param("enable_odom_tf", enable_odom_tf_, enable_odom_tf_);
     ROS_INFO_STREAM_NAMED(name_, "Publishing to tf is " << (enable_odom_tf_?"enabled":"disabled"));
 
-    controller_nh.param("swap_front_and_back", swap_front_and_back_, swap_front_and_back_);
-    ROS_INFO_STREAM_NAMED(name_, "Front and back are " << (swap_front_and_back_?"swapped":"not swapped"));
+    controller_nh.param("invert_forward_direction", invert_forward_direction_, invert_forward_direction_);
+    ROS_INFO_STREAM_NAMED(name_, "Front and back are " << (invert_forward_direction_?"swapped":"not swapped"));
 
     // Velocity and acceleration limits:
     controller_nh.param("linear/x/has_velocity_limits"    , limiter_lin_.has_velocity_limits    , limiter_lin_.has_velocity_limits    );
@@ -439,7 +439,7 @@ namespace diff_drive_controller{
       left_pos  /= wheel_joints_size_;
       right_pos /= wheel_joints_size_;
 
-      if (swap_front_and_back_) {
+      if (invert_forward_direction_) {
         const double temp = left_pos;
         left_pos = -right_pos;
         right_pos = -temp;
@@ -519,7 +519,7 @@ namespace diff_drive_controller{
     double vel_left  = (curr_cmd.lin - curr_cmd.ang * ws / 2.0)/lwr;
     double vel_right = (curr_cmd.lin + curr_cmd.ang * ws / 2.0)/rwr;
 
-    if (swap_front_and_back_) {
+    if (invert_forward_direction_) {
       const double temp = vel_left;
       vel_left = -vel_right;
       vel_right = -temp;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -252,7 +252,7 @@ namespace diff_drive_controller{
     ROS_INFO_STREAM_NAMED(name_, "Publishing to tf is " << (enable_odom_tf_?"enabled":"disabled"));
 
     controller_nh.param("invert_forward_direction", invert_forward_direction_, invert_forward_direction_);
-    ROS_INFO_STREAM_NAMED(name_, "Front and back are " << (invert_forward_direction_?"swapped":"not swapped"));
+    ROS_INFO_STREAM_NAMED(name_, "Forward direction is " << (invert_forward_direction_?"inverted":"not inverted"));
 
     // Velocity and acceleration limits:
     controller_nh.param("linear/x/has_velocity_limits"    , limiter_lin_.has_velocity_limits    , limiter_lin_.has_velocity_limits    );


### PR DESCRIPTION
Simple way of handling the case for redefining the back as the front of the robot. When doing that, basically the left becomes the right wheel, and the spinning directions change for going forward. Hence, the simplest way to achieve this is to swap and negate wheel speed commands before sending them out, and swap and negate encoder readings when they come in.
I didn't really bother that everything is called "left" and "right" in the code with corresponding parameters and would technically all be flipped; if the front is redefined, e.g. the left wheel parameters still apply to the same wheel, not the new left wheel (we are not using wheel specific params anyway)